### PR TITLE
history.push is working fine resolving the video route bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dateformat": "^3.0.3",
     "font-awesome": "^4.7.0",
     "fontsource-roboto": "^3.0.3",
-    "history": "^5.0.0",
+    "history": "^4.10.1",
     "imports-loader": "^1.1.0",
     "jquery": "^3.5.1",
     "lodash": "^4.17.19",


### PR DESCRIPTION
Resolved the lecture route bug by downgrading the history version to 4.10.1 in the package.json file.